### PR TITLE
SystemDesc support for Pose and Stepper systems

### DIFF
--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -9,3 +9,6 @@ mod pose;
 mod stepper;
 
 pub use self::{batch::PhysicsBatchSystem, pose::PhysicsPoseSystem, stepper::PhysicsStepperSystem};
+
+#[cfg(feature = "amethyst")]
+pub use self::{pose::PhysicsPoseSystemDesc, stepper::PhysicsStepperSystemDesc};

--- a/src/systems/pose.rs
+++ b/src/systems/pose.rs
@@ -1,10 +1,11 @@
 use crate::{bodies::{BodyComponent, BodyPartHandle}, nalgebra::RealField, pose::Pose};
-use specs::{Join, ReadStorage, System, WriteStorage};
+use specs::prelude::*;
 use std::marker::PhantomData;
 
 /// The `SyncBodiesFromPhysicsSystem` synchronised the updated position of
 /// the `RigidBody`s in the nphysics `World` with their Specs counterparts. This
 /// affects the `Position` `Component` related to the `Entity`.
+#[cfg_attr(feature = "amethyst", derive(amethyst::derive::SystemDesc), system_desc(name(PhysicsPoseSystemDesc)))]
 pub struct PhysicsPoseSystem<N: RealField, P: Pose<N>>(PhantomData<(N, P)>);
 
 // TODO: Add logging to me!

--- a/src/systems/stepper.rs
+++ b/src/systems/stepper.rs
@@ -6,13 +6,13 @@ use crate::{
     stepper::StepperRes,
     world::{ForceGeneratorSetRes, GeometricalWorldRes, MechanicalWorldRes},
 };
-
-use specs::{Read, System, WriteExpect};
+use specs::prelude::*;
 use std::marker::PhantomData;
 
 /// This system steps the physics world once when called.
 /// To ensure the visual motion of the simulation matches the speeds within the
 /// simulation, you will want to
+#[cfg_attr(feature = "amethyst", derive(amethyst::derive::SystemDesc), system_desc(name(PhysicsStepperSystemDesc)))]
 pub struct PhysicsStepperSystem<N: RealField>(PhantomData<N>);
 
 impl<'s, N: RealField> System<'s> for PhysicsStepperSystem<N> {


### PR DESCRIPTION
Resubmitting PR with cleaner branch. The following builds compile successfully:

* `cargo build --features "dim2"`
* `cargo build --features "dim3"`
* `cargo build --features "dim2 amethyst"` < Need to use patch from #4  first
* `cargo build --features "dim3 amethyst"`

I didn't include a `SystemDesc` for the `Batch` system because it doesn't seem to fit the use case of `SystemDesc`.

I couldn't test the amethyst example due to compile errors.

I couldn't test my personal project with these changes due to issues with how resources are initialized.  Haven't dug too deep into it, but I believe the `World` resources are not initialized for some reason.