### PR TITLE
Fix batch stepper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ keywords = ["specs", "physics", "real-time"]
 default = []
 dim3 = ["ncollide3d", "nphysics3d"]
 dim2 = ["ncollide2d", "nphysics2d"]
+nightly = ["specs/nightly"]
 
 [dependencies]
 log = "0.4"
 objekt = "0.1"
 shrinkwraprs = "0.2"
 
-specs = { version = "0.16", default-features = false }
+specs = "0.15"
 specs-hierarchy = "0.5"
 nalgebra = "0.19"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,13 @@ keywords = ["specs", "physics", "real-time"]
 default = []
 dim3 = ["ncollide3d", "nphysics3d"]
 dim2 = ["ncollide2d", "nphysics2d"]
-nightly = ["specs/nightly"]
 
 [dependencies]
 log = "0.4"
 objekt = "0.1"
 shrinkwraprs = "0.2"
 
-specs = "0.15"
+specs = { version = "0.16", default-features = false }
 specs-hierarchy = "0.5"
 nalgebra = "0.19"
 

--- a/src/stepper/resource.rs
+++ b/src/stepper/resource.rs
@@ -117,13 +117,8 @@ impl StepperRes {
             None
         }
     }
-}
 
-// That's right, I'm clever.
-impl Iterator for StepperRes {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
+    pub fn should_render(&mut self) -> bool {
         let current_frame_delta = self.current_time_step();
         self.is_dirty = false;
 
@@ -145,7 +140,7 @@ impl Iterator for StepperRes {
 
             // Signal end of stepping due to postponement.
             self.frame_steps = 0;
-            None
+            false
         } else if self.accumulator >= current_frame_delta {
             // We may step the simulation once, drain the accumulator.
             self.frame_steps += 1;
@@ -155,20 +150,14 @@ impl Iterator for StepperRes {
             self.is_dirty = current_frame_delta != self.last_delta;
             self.last_delta = current_frame_delta;
 
-            Some(())
+            true
         } else {
             // We've exhausted the accumulator.
             self.time_step.fast_at_step(self.global_steps);
 
             // Signal end of stepping.
             self.frame_steps = 0;
-            None
+            false
         }
-    }
-}
-
-impl Default for StepperRes {
-    fn default() -> Self {
-        Self::new(FixedTimeStep::default())
     }
 }

--- a/src/systems/batch.rs
+++ b/src/systems/batch.rs
@@ -31,7 +31,7 @@ impl<'a, 'b, 's, N: RealField> System<'s> for PhysicsBatchSystem<'a, 'b, N> {
     type SystemData = BatchUncheckedWorld<'s>;
 
     fn run(&mut self, data: Self::SystemData) {
-        for _ in data.0.fetch_mut::<StepperRes>().deref_mut() {
+        while data.0.fetch_mut::<StepperRes>().deref_mut().should_render() {
             self.dispatcher.dispatch(data.0);
         }
     }


### PR DESCRIPTION
When trying to run [Batch Example](https://github.com/distransient/specs-physics/blob/0.4.0/examples/batch.rs) and putting `dispatcher.dispatch(&world);` in a loop:
```rust
loop {
    dispatcher.dispatch(&world);
}
```
I have encountered the following error: `thread '<unnamed>' panicked at 'Tried to fetch data, but it was already borrowed mutably`. 

Investigation revealed that it was because of a mutable borrow in `systems/batch.rs`.

This PR comes with the changes that allowed me to deal with the error, though I am newish to rust and suppose it is not the most efficient way of dealing with this problem.